### PR TITLE
Fix bump-version workflow tag push command

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -84,7 +84,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git push origin HEAD:main
-          git push origin v$(bump-my-version show current_version)
+          git push origin v$(uvx --python 3.12 bump-my-version show current_version)
 
       - name: Build Package
         run: uv build


### PR DESCRIPTION
Use `uvx` to run `bump-my-version` when pushing the version tag, consistent with how it is invoked elsewhere in the workflow.