### PR TITLE
Fix compute_wis_parametric_row NaN poisoning on gappy observations (#91)

### DIFF
--- a/src/laser/cholera/calc_model_likelihood.py
+++ b/src/laser/cholera/calc_model_likelihood.py
@@ -586,7 +586,7 @@ def compute_wis_parametric_row(
     mae_term = 0.0
     if has_med:
         q_med = qfun(0.5)
-        mae_term = 0.5 * float(np.sum(np.abs(y - q_med) * w_use) / np.sum(w_use))
+        mae_term = 0.5 * float(np.nansum(np.abs(y - q_med) * w_use) / np.sum(w_use))
 
     lowers = probs_sorted[probs_sorted < 0.5]
     uppers = probs_sorted[probs_sorted > 0.5]
@@ -609,7 +609,7 @@ def compute_wis_parametric_row(
         width = q_u - q_l
         under = np.maximum(0.0, q_l - y) * (2.0 / alpha)
         over = np.maximum(0.0, y - q_u) * (2.0 / alpha)
-        contrib = float(np.sum((width + under + over) * w_use) / np.sum(w_use))
+        contrib = float(np.nansum((width + under + over) * w_use) / np.sum(w_use))
         sum_is += (alpha / 2.0) * contrib
 
     return float((mae_term + sum_is) / (k_pairs + 0.5))

--- a/tests/test_compute_wis_parametric_row.py
+++ b/tests/test_compute_wis_parametric_row.py
@@ -98,6 +98,57 @@ class TestComputeWisParametricRow:
         # With 0.5 coefficient: WIS = (0.5 * mae) / 0.5 = mae
         assert abs(wis - mae) <= 0.01
 
+    def test_wis_returns_finite_for_partial_na_input(self):
+        """A single non-finite observation does not poison the whole row (issue #91).
+
+        The function zeroes the per-timestep weight at any non-finite cell, but the
+        numerators must drop that cell entirely (R's `na.rm = TRUE`). If they instead
+        form `NaN * 0.0` the IEEE result is `NaN`, which poisons `np.sum` and returns
+        `NaN` for any row with a reporting gap — i.e. effectively every real series.
+
+        Given y with one NaN cell, finite est, uniform weights and k_use=10,
+        when compute_wis_parametric_row is called,
+        then wis should be finite and non-negative (not NaN).
+
+        Failure implies the numerators use `np.sum` rather than `np.nansum`, so a
+        single gap flips a valid score to NaN (the local-vs-Dask WIS divergence).
+        """
+        y = np.array([0.0, 3.0, np.nan, 5.0, 2.0])
+        est = np.array([1.0, 2.5, 4.0, 4.5, 2.0])
+        w = np.ones_like(y)
+        probs = np.array([0.025, 0.25, 0.5, 0.75, 0.975])
+        wis = compute_wis_parametric_row(y, est, w, probs, k_use=10.0)
+        assert np.isfinite(wis)
+        assert wis >= 0
+
+    def test_wis_partial_na_matches_dropped_cell(self):
+        """`na.rm` semantics: a gap cell contributes nothing to the score.
+
+        Because the gap cell carries zero weight, its numerator and denominator
+        contributions are both zero, so scoring the full row with a NaN at index i
+        must equal scoring the row with cell i removed entirely.
+
+        Given a 5-cell row with a NaN at index 2,
+        when compute_wis_parametric_row is called on the full row and on the row with
+            that cell (and its weight) removed,
+        then the two WIS values should be equal.
+
+        Failure implies the zeroed gap cell still influences the weighted average,
+        i.e. the numerator/denominator handling of missing data is inconsistent.
+        """
+        probs = np.array([0.025, 0.25, 0.5, 0.75, 0.975])
+        y_full = np.array([0.0, 3.0, np.nan, 5.0, 2.0])
+        est_full = np.array([1.0, 2.5, 4.0, 4.5, 2.0])
+        w_full = np.ones_like(y_full)
+        keep = ~np.isnan(y_full)
+
+        wis_full = compute_wis_parametric_row(y_full, est_full, w_full, probs, k_use=10.0)
+        wis_dropped = compute_wis_parametric_row(
+            y_full[keep], est_full[keep], w_full[keep], probs, k_use=10.0
+        )
+        assert np.isfinite(wis_full)
+        assert abs(wis_full - wis_dropped) <= 1e-9
+
     def test_wis_works_with_non_standard_quantiles(self):
         """WIS is finite for non-standard quantile levels.
 

--- a/tests/test_compute_wis_parametric_row.py
+++ b/tests/test_compute_wis_parametric_row.py
@@ -143,9 +143,7 @@ class TestComputeWisParametricRow:
         keep = ~np.isnan(y_full)
 
         wis_full = compute_wis_parametric_row(y_full, est_full, w_full, probs, k_use=10.0)
-        wis_dropped = compute_wis_parametric_row(
-            y_full[keep], est_full[keep], w_full[keep], probs, k_use=10.0
-        )
+        wis_dropped = compute_wis_parametric_row(y_full[keep], est_full[keep], w_full[keep], probs, k_use=10.0)
         assert np.isfinite(wis_full)
         assert abs(wis_full - wis_dropped) <= 1e-9
 


### PR DESCRIPTION
Fixes #91.

## Problem

`compute_wis_parametric_row` zeroes the per-timestep weight at any non-finite cell (`w_use[bad] = 0.0`), but then forms the weighted-sum numerators with `np.sum`. At a zeroed cell the observation is `NaN`, so `NaN * 0.0 = NaN` (IEEE) poisons the entire `np.sum` → the function returns `NaN` for **any** row containing a reporting gap, i.e. effectively every real surveillance series.

The R reference (`MOSAIC::calc_model_likelihood`'s `.compute_wis_parametric_row`) computes these same numerators with `na.rm = TRUE`. The sibling cumulative term in this same file already uses `np.nansum` — so this was an internal inconsistency, not a design choice.

## Fix

Switch the two numerators to `np.nansum`; denominators stay `np.sum(w_use)` (`w_use` is finite by construction):

```python
mae_term = 0.5 * float(np.nansum(np.abs(y - q_med) * w_use) / np.sum(w_use))
contrib  =       float(np.nansum((width + under + over) * w_use) / np.sum(w_use))
```

This makes the Python WIS match the R reference and removes the silent local(R)-vs-Dask(Python) WIS scoring divergence. Latent today since `weight_wis` defaults to 0, but a correctness bug the moment WIS is enabled.

## Tests

Added two regression tests to `tests/test_compute_wis_parametric_row.py`:
- `test_wis_returns_finite_for_partial_na_input` — a single-gap row returns a finite, non-negative score (the issue's repro).
- `test_wis_partial_na_matches_dropped_cell` — `na.rm` semantics: scoring a row with a gap equals scoring the row with that cell removed.

Both fail on the unfixed code (return `NaN`) and pass with the fix. Full `tests/test_compute_wis_parametric_row.py` suite: 7 passed.